### PR TITLE
Updates for C/S API changes introduced in 1.0

### DIFF
--- a/cs_kit/__init__.py
+++ b/cs_kit/__init__.py
@@ -1,5 +1,5 @@
 from .api import ComputeStudio
-from .exceptions import CSKitError, SerializationError
+from .exceptions import CSKitException, CSKitError, SerializationError, APIException
 from .schemas import Parameters, ErrorsWarnings
 from .validate import CoreTestFunctions
 
@@ -13,4 +13,8 @@ __all__ = [
     ErrorsWarnings,
     CoreTestFunctions,
     ComputeStudio,
+    CSKitException,
+    CSKitError,
+    SerializationError,
+    APIException,
 ]

--- a/cs_kit/cli.py
+++ b/cs_kit/cli.py
@@ -95,10 +95,15 @@ def cs_token():
     parser.add_argument(
         "--quiet", "-q", help="Just print token", required=False, action="store_true"
     )
+    parser.add_argument(
+        "--host",
+        help="Use another Compute Studio host besides https://compute.studio",
+        default="https://compute.studio",
+    )
     args = parser.parse_args()
 
     resp = requests.post(
-        "https://compute.studio/api-token-auth/",
+        f"{args.host}/api-token-auth/",
         json={"username": args.username, "password": args.password},
     )
     if resp.status_code == 200:

--- a/cs_kit/exceptions.py
+++ b/cs_kit/exceptions.py
@@ -8,3 +8,7 @@ class CSKitError(CSKitException):
 
 class SerializationError(CSKitException):
     pass
+
+
+class APIException(CSKitException):
+    pass


### PR DESCRIPTION
This PR updates the API wrapper to work with C/S 1.0, preserving the previous ability to create simulations via `cs.create(meta_parameters={...}, adjustment={...})` as well as adding the ability to easily edit the title and visibility of a simulation.

```python
from cs_kit import ComputeStudio

cs = ComputeStudio("PSLmodels", "Tax-Brain")

res = cs.create(
    meta_parameters={
        "data_source": "PUF",
        "year": 2020,
    },
    adjustment={
        "policy": {
            "UBI_21": [{"value": 10000, "year": 2020}]
        }
    }
)

model_pk = res["model_pk"]

cs.update_sim(model_pk, title="Hello World", is_public=True)

```
![Screenshot from 2020-02-26 12-50-46](https://user-images.githubusercontent.com/9206065/75372517-a84a4600-5896-11ea-873e-402c4f6e0953.png)


This PR also adds the ability to set which instance your want to get your API token from:

```
csk-token --username hdoupe --password 'some-password' --host https://dev.compute.studio
```