### PR TITLE
Add ok_meta_param_dict to CoreTestFunctions test class

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ class TestFunctions1(CoreTestFunctions):
     get_inputs = functions.get_inputs
     validate_inputs = functions.validate_inputs
     run_model = functions.run_model
+    # ok_meta_param_dict is optional.
+    ok_meta_param_dict = {"full_data": False}
     ok_adjustment={"matchup": {"pitcher": [{"value": "Max Scherzer"}]}}
     bad_adjustment={"matchup": {"pitcher": [{"value": "Not a pitcher"}]}}
 
 ```
+
+- If `ok_meta_param_dict` is set, then it will be used in the `run_model` test
+  along with `ok_adjustment`.
 
 ## Run your cs-config tests
 

--- a/cs_kit/tests/test_FunctionsTest.py
+++ b/cs_kit/tests/test_FunctionsTest.py
@@ -224,3 +224,16 @@ def test_old_bokeh_outputs():
     tf = TestFunctions()
     with pytest.raises(CSKitError):
         tf.test_run_model()
+
+
+def test_specify_meta_param_dict():
+    def run_model_test_mp(meta_param_dict, adjustment):
+        assert meta_param_dict == {"hello_world": [{"value": "hello, there!"}]}
+        return run_model(meta_param_dict, adjustment)
+
+    class TestFunctions(TestFunctions1):
+        ok_meta_param_dict = {"hello_world": "hello, there!"}
+        run_model = run_model_test_mp
+
+    tf = TestFunctions()
+    tf.test_run_model()

--- a/cs_kit/validate.py
+++ b/cs_kit/validate.py
@@ -216,7 +216,10 @@ class CoreTestFunctions(metaclass=CoreTestMeta):
         class MetaParams(Parameters):
             defaults = inputs["meta_parameters"]
 
-        mp_spec = MetaParams().specification(serializable=True)
+        if getattr(self, "ok_meta_param_dict", None) is not None:
+            mp_spec = MetaParams().adjust(self.ok_meta_param_dict)
+        else:
+            mp_spec = MetaParams().specification(serializable=True)
 
         result = self.run_model(mp_spec, self.ok_adjustment)
 


### PR DESCRIPTION
Models may specify `ok_meta_param_dict` as a class attribute on their `TestFunctions` class. `ok_meta_param_dict` will be passed along with `ok_adjustment` to the `run_model` function. Models may use this to run simpler/shorter versions of their models during the Compute Studio CI builds.