### PR TITLE
Update cli to use subparsers

### DIFF
--- a/cs_kit/validate.py
+++ b/cs_kit/validate.py
@@ -22,7 +22,7 @@ def load_model_parameters(model_parameters):
             raise CSKitError(
                 f"An error was thrown while loading the model parameters for section: '{sect}'."
                 f"\n\n\t Hint: Make sure you are using the 'Parameters.dump' method if you are "
-                f"using ParamTools."
+                f"using ParamTools.\n\n{str(ser_exception)}"
             ) from ser_exception
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ setuptools.setup(
     install_requires=["paramtools", "cs-storage", "pandas"],
     include_package_data=True,
     entry_points={
-        "console_scripts": ["csk-init=cs_kit.cli:init", "csk-token=cs_kit.cli:cs_token"]
+        "console_scripts": [
+            "csk-init=cs_kit.cli:init",
+            "csk-token=cs_kit.cli:cs_token",
+            "csk=cs_kit.cli:cli",
+        ]
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The previous commands `csk-token` and `csk-init` still work, but now you can run `csk token` and `csk init`. This makes the CLI a little more flexible and also more ergonomic.