### PR TITLE
Add fsspec implemntation for C/S API

### DIFF
--- a/Filepath API demo.ipynb
+++ b/Filepath API demo.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "# !pip install git+https://github.com/compute-tooling/compute-studio-kit.git@filespec\n",
-    "# !conda install taxcalc -c pslmodels"
+    "!conda install taxcalc -c pslmodels -y"
    ]
   },
   {

--- a/Filepath API demo.ipynb
+++ b/Filepath API demo.ipynb
@@ -6,6 +6,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# !pip install git+https://github.com/compute-tooling/compute-studio-kit.git@filespec\n",
+    "# !conda install taxcalc -c pslmodels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import json\n",
     "\n",
     "import fsspec\n",
@@ -15,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -35,7 +45,7 @@
        "  {'MARS': 'single', 'year': 2019, 'value': 2000000}]}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -48,28 +58,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OrderedDict([('II_rt1', [{'value': 0.25, 'year': 2019}]),\n",
-       "             ('II_rt2', [{'value': 0.25, 'year': 2019}]),\n",
-       "             ('II_rt3', [{'value': 0.25, 'year': 2019}]),\n",
-       "             ('II_rt4', [{'value': 0.25, 'year': 2019}]),\n",
-       "             ('II_rt5', [{'value': 0.25, 'year': 2019}]),\n",
-       "             ('II_rt6', [{'value': 0.25, 'year': 2019}]),\n",
+       "OrderedDict([('II_rt1', [{'year': 2019, 'value': 0.25}]),\n",
+       "             ('II_rt2', [{'year': 2019, 'value': 0.25}]),\n",
+       "             ('II_rt3', [{'year': 2019, 'value': 0.25}]),\n",
+       "             ('II_rt4', [{'year': 2019, 'value': 0.25}]),\n",
+       "             ('II_rt5', [{'year': 2019, 'value': 0.25}]),\n",
+       "             ('II_rt6', [{'year': 2019, 'value': 0.25}]),\n",
        "             ('II_brk6',\n",
-       "              [{'value': 2000000.0, 'year': 2019, 'MARS': 'widow'},\n",
-       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'headhh'},\n",
-       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'mseparate'},\n",
-       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'mjoint'},\n",
-       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'single'}]),\n",
-       "             ('II_rt7', [{'value': 0.7, 'year': 2019}])])"
+       "              [{'year': 2019, 'value': 2000000.0, 'MARS': 'widow'},\n",
+       "               {'year': 2019, 'value': 2000000.0, 'MARS': 'headhh'},\n",
+       "               {'year': 2019, 'value': 2000000.0, 'MARS': 'mseparate'},\n",
+       "               {'year': 2019, 'value': 2000000.0, 'MARS': 'mjoint'},\n",
+       "               {'year': 2019, 'value': 2000000.0, 'MARS': 'single'}]),\n",
+       "             ('II_rt7', [{'year': 2019, 'value': 0.7}])])"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -83,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +218,7 @@
        "2  $678.08  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -228,7 +238,7 @@
        "{'owner': 'MaxGhenis'}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -251,7 +261,7 @@
        "{'title': 'Super secret sim'}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/Filepath API demo.ipynb
+++ b/Filepath API demo.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import fsspec\n",
+    "\n",
+    "from cs_kit.filespec import CSFileSystem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'II_rt1': [{'year': 2019, 'value': 0.25}],\n",
+       " 'II_rt2': [{'year': 2019, 'value': 0.25}],\n",
+       " 'II_rt3': [{'year': 2019, 'value': 0.25}],\n",
+       " 'II_rt4': [{'year': 2019, 'value': 0.25}],\n",
+       " 'II_rt5': [{'year': 2019, 'value': 0.25}],\n",
+       " 'II_rt6': [{'year': 2019, 'value': 0.25}],\n",
+       " 'II_rt7': [{'year': 2019, 'value': 0.7}],\n",
+       " 'II_brk6': [{'MARS': 'widow', 'year': 2019, 'value': 2000000},\n",
+       "  {'MARS': 'headhh', 'year': 2019, 'value': 2000000},\n",
+       "  {'MARS': 'mseparate', 'year': 2019, 'value': 2000000},\n",
+       "  {'MARS': 'mjoint', 'year': 2019, 'value': 2000000},\n",
+       "  {'MARS': 'single', 'year': 2019, 'value': 2000000}]}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with fsspec.open(\"cs://PSLmodels:Tax-Brain@47410/inputs/adjustment/policy/\", \"r\") as f:\n",
+    "    data = json.loads(f.read())\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('II_rt1', [{'value': 0.25, 'year': 2019}]),\n",
+       "             ('II_rt2', [{'value': 0.25, 'year': 2019}]),\n",
+       "             ('II_rt3', [{'value': 0.25, 'year': 2019}]),\n",
+       "             ('II_rt4', [{'value': 0.25, 'year': 2019}]),\n",
+       "             ('II_rt5', [{'value': 0.25, 'year': 2019}]),\n",
+       "             ('II_rt6', [{'value': 0.25, 'year': 2019}]),\n",
+       "             ('II_brk6',\n",
+       "              [{'value': 2000000.0, 'year': 2019, 'MARS': 'widow'},\n",
+       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'headhh'},\n",
+       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'mseparate'},\n",
+       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'mjoint'},\n",
+       "               {'value': 2000000.0, 'year': 2019, 'MARS': 'single'}]),\n",
+       "             ('II_rt7', [{'value': 0.7, 'year': 2019}])])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import taxcalc\n",
+    "\n",
+    "pol = taxcalc.Policy()\n",
+    "pol.adjust(\"cs://PSLmodels:Tax-Brain@47410/inputs/adjustment/policy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "\n",
+    "import pandas as pd\n",
+    "import paramtools\n",
+    "\n",
+    "data = paramtools.read_json(\"cs://PSLmodels:Tax-Brain@47410/outputs\")\n",
+    "\n",
+    "results = []\n",
+    "for output in data:\n",
+    "    results.append(\n",
+    "        pd.read_csv(io.StringIO(output[\"data\"]))\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>2019</th>\n",
+       "      <th>2020</th>\n",
+       "      <th>2021</th>\n",
+       "      <th>2022</th>\n",
+       "      <th>2023</th>\n",
+       "      <th>2024</th>\n",
+       "      <th>2025</th>\n",
+       "      <th>2026</th>\n",
+       "      <th>2027</th>\n",
+       "      <th>2028</th>\n",
+       "      <th>2029</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Individual Income Tax Liability Change</td>\n",
+       "      <td>$651.31</td>\n",
+       "      <td>$677.74</td>\n",
+       "      <td>$707.50</td>\n",
+       "      <td>$735.71</td>\n",
+       "      <td>$764.94</td>\n",
+       "      <td>$793.97</td>\n",
+       "      <td>$824.71</td>\n",
+       "      <td>$609.33</td>\n",
+       "      <td>$631.98</td>\n",
+       "      <td>$654.94</td>\n",
+       "      <td>$678.08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Payroll Tax Liability Change</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "      <td>$0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Combined Payroll and Individual Income Tax Lia...</td>\n",
+       "      <td>$651.31</td>\n",
+       "      <td>$677.74</td>\n",
+       "      <td>$707.50</td>\n",
+       "      <td>$735.71</td>\n",
+       "      <td>$764.94</td>\n",
+       "      <td>$793.97</td>\n",
+       "      <td>$824.71</td>\n",
+       "      <td>$609.33</td>\n",
+       "      <td>$631.98</td>\n",
+       "      <td>$654.94</td>\n",
+       "      <td>$678.08</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                          Unnamed: 0     2019     2020  \\\n",
+       "0             Individual Income Tax Liability Change  $651.31  $677.74   \n",
+       "1                       Payroll Tax Liability Change    $0.00    $0.00   \n",
+       "2  Combined Payroll and Individual Income Tax Lia...  $651.31  $677.74   \n",
+       "\n",
+       "      2021     2022     2023     2024     2025     2026     2027     2028  \\\n",
+       "0  $707.50  $735.71  $764.94  $793.97  $824.71  $609.33  $631.98  $654.94   \n",
+       "1    $0.00    $0.00    $0.00    $0.00    $0.00    $0.00    $0.00    $0.00   \n",
+       "2  $707.50  $735.71  $764.94  $793.97  $824.71  $609.33  $631.98  $654.94   \n",
+       "\n",
+       "      2029  \n",
+       "0  $678.08  \n",
+       "1    $0.00  \n",
+       "2  $678.08  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'owner': 'MaxGhenis'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with fsspec.open(\"cs://PSLmodels:Tax-Brain@47410/owner\") as f:\n",
+    "    result = json.loads(f.read())\n",
+    "\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'title': 'Super secret sim'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with fsspec.open(\"cs://PSLmodels:Tax-Cruncher@520/title\", api_token=\"your-api-token\") as f:\n",
+    "    result = json.loads(f.read())\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/cs_kit/__init__.py
+++ b/cs_kit/__init__.py
@@ -2,19 +2,21 @@ from .api import ComputeStudio
 from .exceptions import CSKitException, CSKitError, SerializationError, APIException
 from .schemas import Parameters, ErrorsWarnings
 from .validate import CoreTestFunctions
+from .filespec import CSFileSystem
 
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 
 
 __all__ = [
-    CSKitError,
-    SerializationError,
-    Parameters,
-    ErrorsWarnings,
-    CoreTestFunctions,
-    ComputeStudio,
-    CSKitException,
-    CSKitError,
-    SerializationError,
-    APIException,
+    "CSKitError",
+    "SerializationError",
+    "Parameters",
+    "ErrorsWarnings",
+    "CoreTestFunctions",
+    "ComputeStudio",
+    "CSKitException",
+    "CSKitError",
+    "SerializationError",
+    "APIException",
+    "CSFileSystem",
 ]

--- a/cs_kit/filespec.py
+++ b/cs_kit/filespec.py
@@ -1,0 +1,132 @@
+import json
+
+from fsspec.spec import AbstractFileSystem
+from fsspec.registry import register_implementation
+from fsspec.utils import infer_storage_options
+from fsspec.implementations.memory import MemoryFile
+import requests
+
+
+class CSFileSystem(AbstractFileSystem):
+    """
+    Interface to data on Compute Studio
+
+    When using fsspec.open, allows URIs of the form:
+
+    - cs://owner:title@model-pk/ : get meta data for simulation
+    - cs://owner:title@model-pk/inputs : get inputs metadata for simulation
+    - cs://owner:title@model-pk/inputs/adjustment : get full adjustment
+    - cs://owner:title@model-pk/input/adjustment/section : get specific section of adjustment
+    - cs://owner:title@model-pk/outputs : get outputs from reform
+    - cs://owner:title@model-pk/owner : get owner of simulation
+    - cs://owner:title@model-pk/title : get title of simulation
+
+    For authorised access, you must provide an API Token, which can be made
+    at https://docs.compute.studio/api/auth/. The API Token can be specified like:
+
+    with fsspec.open("cs://PSLmodels:Tax-Brain@1234", api_token=api_token) as f:
+        result = f.read()
+
+    Modified version of the GitHub fsspec implementation:
+    - https://filesystem-spec.readthedocs.io/en/latest/api.html#id0
+    """
+
+    url = "https://compute.studio/{owner}/{title}/api/v1/{model_pk}/"
+    protocol = "cs"
+
+    def __init__(
+        self,
+        owner,
+        title,
+        model_pk,
+        resource=None,
+        field=None,
+        section=None,
+        api_token=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.owner = owner
+        self.title = title
+        self.model_pk = model_pk
+        self.resource = resource
+        self.field = field
+        self.section = section
+        self.api_token = api_token
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        opts = infer_storage_options(path)
+        if "username" not in opts:
+            return super()._strip_protocol(path)
+        return opts["path"].lstrip("/")
+
+    @staticmethod
+    def _get_kwargs_from_urls(path):
+        opts = infer_storage_options(path)
+        out = {"owner": opts["username"], "title": opts["password"]}
+        if opts["host"]:
+            out["model_pk"] = opts["host"]
+
+        path = opts["path"]
+        if len(path) > 0:
+            parts = path[1:].split("/")
+        else:
+            parts = []
+
+        if len(parts) > 0 and parts[0] in ("inputs", "outputs", "owner", "title"):
+            out["resource"] = parts[0]
+
+        if len(parts) > 1 and parts[1] in ("adjustment", "meta_parameters", "title"):
+            out["field"] = parts[1]
+
+        if len(parts) > 2 and parts[1] == "adjustment":
+            out["section"] = parts[2]
+
+        return out
+
+    def _open(self, path, mode="rb", block_size=None, **kwargs):
+        if mode != "rb":
+            raise NotImplementedError
+        base_url = self.url.format(
+            owner=self.owner, title=self.title, model_pk=self.model_pk,
+        )
+
+        if self.resource == "inputs":
+            url = base_url + "edit/"
+        elif self.resource is None:
+            url = base_url + "remote/"
+        else:
+            url = base_url
+
+        if self.api_token is not None:
+            headers = {"Authorization": f"Token {self.api_token}"}
+        else:
+            headers = None
+
+        r = requests.get(url, headers=headers)
+        if r.status_code == 404:
+            raise FileNotFoundError(path)
+        r.raise_for_status()
+
+        data = r.json()
+        if self.resource == "inputs" and self.field is None:
+            result = data
+        elif self.resource == "inputs" and self.field != "adjustment":
+            result = data[self.field]
+        elif self.resource == "inputs" and self.field == "adjustment":
+            result = data[self.field]
+            if self.section is not None:
+                result = result[self.section]
+        elif self.resource == "outputs":
+            result = data["outputs"]["downloadable"]
+        elif self.resource in ("title", "owner"):
+            result = {self.resource: data[self.resource]}
+        elif self.resource is None:
+            result = dict(data, outputs=base_url)
+        else:
+            raise FileNotFoundError()
+        return MemoryFile(None, None, json.dumps(result).encode("utf-8"))
+
+
+register_implementation("cs", CSFileSystem)

--- a/cs_kit/filespec.py
+++ b/cs_kit/filespec.py
@@ -17,6 +17,7 @@ class CSFileSystem(AbstractFileSystem):
     - cs://owner:title@model-pk/inputs : get inputs metadata for simulation
     - cs://owner:title@model-pk/inputs/adjustment : get full adjustment
     - cs://owner:title@model-pk/input/adjustment/section : get specific section of adjustment
+    - cs://owner:title@model-pk/input/meta_parameters : get meta_parameters
     - cs://owner:title@model-pk/outputs : get outputs from reform
     - cs://owner:title@model-pk/owner : get owner of simulation
     - cs://owner:title@model-pk/title : get title of simulation

--- a/cs_kit/tests/test_filespec.py
+++ b/cs_kit/tests/test_filespec.py
@@ -1,0 +1,42 @@
+import io
+import json
+import fsspec
+
+import pandas as pd
+import paramtools
+
+import cs_kit
+
+
+def test_get_inputs():
+    with fsspec.open(
+        "cs://PSLmodels:Tax-Brain@47517/inputs/adjustment/policy", "r"
+    ) as f:
+        assert json.loads(f.read())
+
+    with fsspec.open("cs://PSLmodels:Tax-Brain@47517/inputs/adjustment", "r") as f:
+        assert json.loads(f.read())
+
+    with fsspec.open(
+        "cs://PSLmodels:Tax-Brain@47517/inputs/adjustment/policy", "r"
+    ) as f:
+        assert json.loads(f.read())
+
+    with fsspec.open("cs://PSLmodels:Tax-Brain@47517/inputs/meta_parameters", "r") as f:
+        assert json.loads(f.read())
+
+
+def test_get_outputs():
+    data = paramtools.read_json("cs://PSLmodels:Tax-Brain@47517/outputs")
+    for output in data:
+        assert isinstance(pd.read_csv(io.StringIO(output["data"])), pd.DataFrame)
+
+
+def test_get_owner():
+    data = paramtools.read_json("cs://PSLmodels:Tax-Brain@47517/owner")
+    assert data == {"owner": "hdoupe"}
+
+
+def test_get_title():
+    data = paramtools.read_json("cs://PSLmodels:Tax-Brain@47517/title")
+    assert data == {"title": "Test TB after updates"}

--- a/environment.yml
+++ b/environment.yml
@@ -10,5 +10,6 @@ dependencies:
   - pre-commit
   - black
   - flake8
+  - fsspec
   - pip:
-    - cs-storage
+      - cs-storage

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/compute-studio-org/Compute-Studio-Toolkit",
     packages=setuptools.find_packages(),
-    install_requires=["paramtools", "cs-storage", "pandas"],
+    install_requires=["paramtools", "cs-storage", "pandas", "fsspec"],
     include_package_data=True,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Uses fsspec to create a file-path like experience for working with the C/S API. This makes it easy to integrate C/S data into other tooling:
- `cs://owner:title@model-pk/` : get meta data for simulation
- `cs://owner:title@model-pk/inputs` : get inputs metadata for simulation
- `cs://owner:title@model-pk/inputs/adjustment` : get full adjustment
- `cs://owner:title@model-pk/input/adjustment/section` : get specific section of adjustment
- `cs://owner:title@model-pk/input/meta_parameters` : get meta_parameters
- `cs://owner:title@model-pk/outputs` : get outputs from reform
- `cs://owner:title@model-pk/owner` : get owner of simulation
- `cs://owner:title@model-pk/title` : get title of simulation


Following the [fsspec implementation for GitHub](https://filesystem-spec.readthedocs.io/en/latest/api.html#id0) made it easy to put a prototype together. I think there are some other cool things that can be done with this like implementing `ls` and maybe even allowing some write operations for updating the title or description.

cc @maxghenis