### PR TITLE
Add inputs method for retrieving inputs for a sim

### DIFF
--- a/cs_kit/api.py
+++ b/cs_kit/api.py
@@ -63,6 +63,18 @@ class ComputeStudio:
                 raise APIException(resp.text)
             time.sleep(5)
 
+    def inputs(self, model_pk=None):
+        if model_pk is None:
+            resp = requests.get(f"{self.sim_url}inputs/", headers=self.auth_header)
+            resp.raise_for_status()
+            return resp.json()
+        else:
+            resp = requests.get(
+                f"{self.sim_url}{model_pk}/edit/", headers=self.auth_header
+            )
+            resp.raise_for_status()
+            return resp.json()
+
     def results(self, model_pk):
         result = self.detail(model_pk)
         res = {}
@@ -116,7 +128,9 @@ class ComputeStudio:
                 f"Extra arguments were given to update_sim: {extra_kwargs}"
             )
         resp = requests.put(
-            f"{self.sim_url}{model_pk}/", json=sim_kwargs, headers=self.auth_header,
+            f"{self.sim_url}{model_pk}/",
+            json=sim_kwargs,
+            headers=self.auth_header,
         )
         if resp.status_code == 200:
             return resp.json()


### PR DESCRIPTION
```python
In [1]: import cs_kit

In [2]: taxbrain_client = cs_kit.ComputeStudio("PSLmodels", "Tax-Brain")

In [3]: taxbrain_params = taxbrain_client.inputs(model_pk=49797)["adjustment"]

In [4]: taxbrain_params["policy"]["EITC_c"]
Out[4]: 
[{'EIC': '0kids', 'year': 2017, 'value': 510.0},
 {'EIC': '1kid', 'year': 2017, 'value': 3400.0},
 {'EIC': '2kids', 'year': 2017, 'value': 5616.0},
 {'EIC': '3+kids', 'year': 2017, 'value': 6318.0}]
```