### PR TITLE
Fix bug caused by greater than pins

### DIFF
--- a/cs_kit/buildpacks.py
+++ b/cs_kit/buildpacks.py
@@ -25,6 +25,9 @@ class PythonBuildpack:
                 if isinstance(dep, dict) and dep.get("pip"):
                     pip_requirements = dep["pip"]
                 else:
+                    if ">" in dep or "<" in dep:
+                        dep = dep.replace('"', "")
+                        dep = f'"{dep}"'
                     conda_requirements.append(dep)
 
         if Path(self.requirements_txt_path).exists():
@@ -69,4 +72,3 @@ def run(cmd):
     f = time.time()
     print(f"\n\tFinished in {f-s} seconds.\n")
     return res
-

--- a/cs_kit/tests/taxcrunch_environment.yml
+++ b/cs_kit/tests/taxcrunch_environment.yml
@@ -1,0 +1,17 @@
+name: taxcrunch-env
+channels:
+  - PSLmodels
+  - conda-forge
+dependencies:
+  - python>=3.6.5
+  - taxcalc>=3.0.0
+  - behresp>=0.9.0
+  - pandas>=0.23
+  - numpy>=1.13
+  - paramtools>=0.10.1
+  - pytest
+  - bokeh<2.0.0
+  - coverage
+  - pip
+  - pip:
+      - cs-kit

--- a/cs_kit/tests/test_buildpacks.py
+++ b/cs_kit/tests/test_buildpacks.py
@@ -35,3 +35,12 @@ def test_buildpacks(monkeypatch):
     assert cmds == [
         "pip install cs-kit",
     ]
+
+    cmds[:] = []
+    buildpacks.PythonBuildpack(
+        environment_yml_path=Path(current_dir / "taxcrunch_environment.yml")
+    ).build()
+    assert cmds == [
+        'conda install -y "python>=3.6.5" "taxcalc>=3.0.0" "behresp>=0.9.0" "pandas>=0.23" "numpy>=1.13" "paramtools>=0.10.1" pytest "bokeh<2.0.0" coverage pip',
+        "pip install cs-kit",
+    ]


### PR DESCRIPTION
Fixes error message:

```
Step 14/18 : RUN csk build-env
 ---> Running in 9fc5cdd52b99
/bin/sh: 1: cannot open 2.0.0: No such file
Running: conda install -y python>=3.6.5 taxcalc>=3.0.0 behresp>=0.9.0 pandas>=0.23 numpy>=1.13 paramtools>=0.10.1 pytest bokeh<2.0.0 coverage pip

Traceback (most recent call last):
  File "/opt/conda/bin/csk", line 8, in <module>
    sys.exit(cli())
  File "/opt/conda/lib/python3.7/site-packages/cs_kit/cli.py", line 155, in cli
    args.func(args)
  File "/opt/conda/lib/python3.7/site-packages/cs_kit/cli.py", line 138, in <lambda>
    parser.set_defaults(func=lambda args: buildpacks.build_env())
  File "/opt/conda/lib/python3.7/site-packages/cs_kit/buildpacks.py", line 62, in build_env
    buildpack().build()
  File "/opt/conda/lib/python3.7/site-packages/cs_kit/buildpacks.py", line 42, in build
    run(f"conda install -y {' '.join(reqs['conda_requirements'])}")
  File "/opt/conda/lib/python3.7/site-packages/cs_kit/buildpacks.py", line 68, in run
    res = subprocess.run(cmd, shell=True, check=True)
  File "/opt/conda/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command 'conda install -y python>=3.6.5 taxcalc>=3.0.0 behresp>=0.9.0 pandas>=0.23 numpy>=1.13 paramtools>=0.10.1 pytest bokeh<2.0.0 coverage pip' returned non-zero exit status 2.
```